### PR TITLE
Set team annotation in Chart.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Set team annotation in Chart.yaml for alert routing.
+
 ## [0.4.0] - 2021-07-29
 
 ### Changed

--- a/helm/linkerd2-cni-app/Chart.yaml
+++ b/helm/linkerd2-cni-app/Chart.yaml
@@ -10,6 +10,8 @@ engine: gotpl
 home: https://github.com/giantswarm/linkerd2-cni-app
 icon: https://s.giantswarm.io/app-icons/1/png/linkerd2-app-light.png
 kubeVersion: ">=1.16.0-0"
+annotations:
+  application.giantswarm.io/team: team-cabbage
 maintainers:
 - email: cncf-linkerd-dev@lists.cncf.io
   name: Linkerd authors


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/639

I checked the latest scorecard and the team annotation is needed here. Other apps are OK. ✅ 

https://github.com/giantswarm/giantswarm/issues/20179