### PR TITLE
Add Giant Swarm team label to resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Update pytest-helm-charts from beta to [v0.7.0](https://github.com/giantswarm/pytest-helm-charts/blob/master/CHANGELOG.md) ([#68](https://github.com/giantswarm/linkerd2-cni-app/pull/68))
+- Add Giant Swarm team label to resources.
 
 ## [0.7.0] - 2022-05-12
 

--- a/helm/linkerd2-cni-app/templates/cni-plugin.yaml
+++ b/helm/linkerd2-cni-app/templates/cni-plugin.yaml
@@ -28,6 +28,7 @@ metadata:
     linkerd.io/cni-resource: "true"
     config.linkerd.io/admission-webhooks: disabled
     giantswarm.io/service-type: "managed"
+    application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | quote }}
 ---
 {{ end -}}
 apiVersion: v1
@@ -38,6 +39,7 @@ metadata:
   labels:
     linkerd.io/cni-resource: "true"
     giantswarm.io/service-type: "managed"
+    application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | quote }}
 {{- if .Values.imagePullSecrets }}
 imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets | indent 2 }}
@@ -51,6 +53,7 @@ metadata:
   labels:
     linkerd.io/cni-resource: "true"
     giantswarm.io/service-type: "managed"
+    application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | quote }}
 spec:
   allowPrivilegeEscalation: false
   fsGroup:
@@ -75,6 +78,7 @@ metadata:
   labels:
     linkerd.io/cni-resource: "true"
     giantswarm.io/service-type: "managed"
+    application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | quote }}
 rules:
 - apiGroups: ['extensions', 'policy']
   resources: ['podsecuritypolicies']
@@ -90,6 +94,7 @@ metadata:
   labels:
     linkerd.io/cni-resource: "true"
     giantswarm.io/service-type: "managed"
+    application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | quote }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -107,6 +112,7 @@ metadata:
   labels:
     linkerd.io/cni-resource: "true"
     giantswarm.io/service-type: "managed"
+    application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | quote }}
 rules:
 - apiGroups: [""]
   resources: ["pods", "nodes", "namespaces"]
@@ -119,6 +125,7 @@ metadata:
   labels:
     linkerd.io/cni-resource: "true"
     giantswarm.io/service-type: "managed"
+    application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | quote }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -136,6 +143,7 @@ metadata:
   labels:
     linkerd.io/cni-resource: "true"
     giantswarm.io/service-type: "managed"
+    application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | quote }}
 data:
   dest_cni_net_dir: "{{.Values.destCNINetDir}}"
   dest_cni_bin_dir: "{{.Values.destCNIBinDir}}"
@@ -181,6 +189,7 @@ metadata:
     linkerd.io/cni-resource: "true"
     giantswarm.io/monitoring_basic_sli: "true"
     giantswarm.io/service-type: "managed"
+    application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | quote }}
   annotations:
     {{ include "partials.annotations.created-by" . }}
 spec:
@@ -196,6 +205,7 @@ spec:
       labels:
         k8s-app: linkerd-cni
         giantswarm.io/service-type: "managed"
+        application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | quote }}
       annotations:
         {{ include "partials.annotations.created-by" . }}
     spec:


### PR DESCRIPTION
This PR adds the GiantSwarm team label to all resources

Towards https://github.com/giantswarm/giantswarm/issues/22715 and https://github.com/giantswarm/giantswarm/issues/22715

## Checklist

- [x] Changelog entry has been added
