### PR TITLE
Add icon to Chart.yaml for happa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add icon url to chart
+
 ## [0.8.0] - 2022-10-27
 
 ### Changed

--- a/helm/linkerd2-cni/Chart.yaml
+++ b/helm/linkerd2-cni/Chart.yaml
@@ -7,10 +7,11 @@ description: |
   up your pod's network so  incoming and outgoing traffic is proxied through the
   data plane.
 home: https://github.com/giantswarm/linkerd2-cni-app
-icon: https://s.giantswarm.io/app-icons/1/png/linkerd2-app-light.png
+icon: https://s.giantswarm.io/app-icons/linkerd2/2/icon_dark.svg
 kubeVersion: ">=1.21.0-0"
 annotations:
   application.giantswarm.io/team: team-cabbage
+  ui.giantswarm.io/logo: https://s.giantswarm.io/app-icons/linkerd2/2/logo_dark.svg
 dependencies:
   - name: partials
     version: 0.1.0


### PR DESCRIPTION

This PR adds an icon to the `Chart.yaml` and moves the old icon, which was actually a logo, to the annotations.

## Checklist

- [x] Changelog entry has been added
