### PR TITLE
Changes priority class to system-node-critical to improve chances to …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add icon url to chart
 
+### Changed
+
+- Changes linkerd CNI priority class to "giantswarm-critical" to improve scheduling.
+
 ## [0.8.0] - 2022-10-27
 
 ### Changed

--- a/helm/linkerd2-cni/README.md
+++ b/helm/linkerd2-cni/README.md
@@ -38,7 +38,7 @@ Kubernetes: `>=1.21.0-0`
 | logLevel | string | `"info"` | Log level for the CNI plugin |
 | outboundProxyPort | int | `4140` | Outbound port for the proxy container |
 | portsToRedirect | string | `""` | Ports to redirect to proxy |
-| priorityClassName | string | `""` | Kubernetes priorityClassName for the CNI plugin's Pods |
+| priorityClassName | string | `"giantswarm-critical"` | Kubernetes priorityClassName for the CNI plugin's Pods |
 | privileged | bool | `false` | Run the install-cni container in privileged mode |
 | proxyAdminPort | int | `4191` | Admin port for the proxy container |
 | proxyControlPort | int | `4190` | Control port for the proxy container |

--- a/helm/linkerd2-cni/values.yaml
+++ b/helm/linkerd2-cni/values.yaml
@@ -27,7 +27,7 @@ destCNIBinDir: "/opt/cni/bin"
 # -- Configures the CNI plugin to use the -w flag for the iptables command
 useWaitFlag: false
 # -- Kubernetes priorityClassName for the CNI plugin's Pods
-priorityClassName: ""
+priorityClassName: "giantswarm-critical"
 
 # -- Add a PSP resource and bind it to the linkerd-cni ServiceAccounts.
 # Note PSP has been deprecated since k8s v1.21


### PR DESCRIPTION
…be correctly scheduled

<!--
@giantswarm/team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

This PR modifies the priority class of linkerd CNI to improve chances to be scheduled on situations where there is higher pressure on the node. As linkerd is a critical component on a cluster, having it broken can lead to services unable to properly communicate with each other, or falling back to unmeshed communication, which can create other issues.

## Checklist

- [ ] Automated test are working (for chart changes)
- [x] I am confident my changes don't break existing installations (for chart changes)
- [x] Changelog entry has been added
