### PR TITLE
update chart to linkerd v2.13.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade to linkerd 2.13.6
+
 ## [1.0.0] - 2023-06-13
 
 ### Changed

--- a/helm/linkerd2-cni/Chart.yaml
+++ b/helm/linkerd2-cni/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: stable-2.13.4
+appVersion: stable-2.13.6
 description: |
   Linkerd is a *service mesh*, designed to give platform-wide observability,
   reliability, and security without requiring configuration or code changes. The

--- a/helm/linkerd2-cni/templates/cni-plugin.yaml
+++ b/helm/linkerd2-cni/templates/cni-plugin.yaml
@@ -57,7 +57,6 @@ spec:
   {{- end }}
   fsGroup:
     rule: RunAsAny
-  hostNetwork: true
   runAsUser:
     rule: RunAsAny
   seLinux:
@@ -212,7 +211,6 @@ spec:
       affinity:
       {{- include "linkerd.node-affinity" . | nindent 8 }}
       {{- end }}
-      hostNetwork: true
       securityContext:
         seccompProfile:
           type: RuntimeDefault

--- a/helm/linkerd2-cni/values.yaml
+++ b/helm/linkerd2-cni/values.yaml
@@ -57,7 +57,7 @@ image:
   # -- Docker image for the CNI plugin
   name: "giantswarm/linkerd2-cni-plugin"
   # -- Tag for the CNI container Docker image
-  version: "v1.1.1"
+  version: "v1.2.0"
   # -- Pull policy for the linkerd-cni container
   pullPolicy: IfNotPresent
 
@@ -72,14 +72,6 @@ image:
 # The pull secrets are applied to the respective service accounts
 # which will further orchestrate the deployments.
 imagePullSecrets: []
-
-resources:
-  cpu:
-    limit: "500m"
-    request: "50m"
-  memory:
-    limit: "128Mi"
-    request: "64Mi"
 
 # -- Add additional initContainers to the daemonset
 extraInitContainers: []
@@ -97,3 +89,21 @@ extraInitContainers: []
 #   volumeMounts:
 #     - mountPath: /host/etc/cni/net.d
 #       name: cni-net-dir
+
+# -- Resource requests and limits for linkerd-cni daemonset containers
+resources:
+  cpu:
+    # -- Maximum amount of CPU units that the cni container can use
+    limit: "500m"
+    # -- Amount of CPU units that the cni container requests
+    request: "50m"
+  memory:
+    # -- Maximum amount of memory that the cni container can use
+    limit: "128Mi"
+    # -- Amount of memory that the cni container requests
+    request: "64Mi"
+  ephemeral-storage:
+    # -- Maximum amount of ephemeral storage that the cni container can use
+    limit: ""
+    # -- Amount of ephemeral storage that the cni container requests
+    request: ""

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -2,10 +2,11 @@ apiVersion: vendir.k14s.io/v1alpha1
 directories:
 - contents:
   - git:
-      commitTitle: Merge branch 'release/stable-2.13' into stable-2.13.x
-      sha: f35bd7d4086dda12a3c4b4f667aa8abf3847489d
+      commitTitle: Merge remote-tracking branch 'upstream/release/stable-2.13' into
+        stable-2.13.x
+      sha: ea513a4b04dd1515dec9e6ee0b44cafa4785fd63
       tags:
-      - stable-2.10.1-2933-gf35bd7d40
+      - stable-2.10.1-2949-gea513a4b0
     path: linkerd
   path: vendor
 - contents:


### PR DESCRIPTION
Signed-off-by: Matias Charriere <matias@giantswarm.io>

Upgrade to v2.13.6. Uses linkerd-cni v1.2.0