### PR TITLE
Remove node taint when CNI is ready

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add node-taint container for taint removal.
+- Restrict tolerators to avoid scheduling on nodes with `node.cilium.io/agent-not-ready`.
+
 ## [1.2.1] - 2023-10-11
 
 ### Changed

--- a/helm/linkerd2-cni/templates/cni-plugin.yaml
+++ b/helm/linkerd2-cni/templates/cni-plugin.yaml
@@ -112,6 +112,9 @@ rules:
 - apiGroups: [""]
   resources: ["pods", "nodes", "namespaces", "services"]
   verbs: ["list", "get", "watch"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -257,6 +260,59 @@ spec:
               - /bin/sh
               - -c
               - kill -15 1; sleep 15s
+        volumeMounts:
+        {{- if ne .Values.destCNIBinDir .Values.destCNINetDir }}
+        - mountPath: /host{{.Values.destCNIBinDir}}
+          name: cni-bin-dir
+        - mountPath: /host{{.Values.destCNINetDir}}
+          name: cni-net-dir
+        {{- else }}
+        - mountPath: /host{{.Values.destCNINetDir}}
+          name: cni-net-dir
+        {{- end }}
+        - mountPath: /tmp
+          name: linkerd-tmp-dir
+        securityContext:
+          readOnlyRootFilesystem: true
+          privileged: {{.Values.privileged}}
+        {{- if .Values.resources }}
+        {{- include "partials.resources" .Values.resources | nindent 8 }}
+        {{- end }}
+      - name: node-taint
+        image: "{{ .Values.image.registry }}/giantswarm/docker-kubectl:1.24.2"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command:
+          - /bin/sh
+          - -c
+          - | 
+            while true; do 
+              # Check for taint. If it's not there, sleep for 10hs.
+              kubectl get nodes -o custom-columns=NAME:.metadata.name,TAINTS:.spec.taints --no-headers "$KUBERNETES_NODE" | grep -q node.giantswarm.io/mesh-not-ready || (echo "No taint found. Sleeping now..." && sleep 36000 && continue)
+              # If the node has a taint; check if the CNI is configured and remove the taint if true. Sleep for 10hs afterwards.
+              grep -q "linkerd-cni" /host$DEST_CNI_NET_DIR/*.conflist && kubectl taint node "$KUBERNETES_NODE" node.giantswarm.io/mesh-not-ready- && echo "Taint on $KUBERNETES_NODE removed. Sleeping now..." && sleep 36000;
+              # Safeguard
+              sleep 60
+            done
+        env:
+        - name: KUBERNETES_NODE
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: DEST_CNI_NET_DIR
+          valueFrom:
+            configMapKeyRef:
+              name: linkerd-cni-config
+              key: dest_cni_net_dir
+        - name: DEST_CNI_BIN_DIR
+          valueFrom:
+            configMapKeyRef:
+              name: linkerd-cni-config
+              key: dest_cni_bin_dir
+        - name: CNI_NETWORK_CONFIG
+          valueFrom:
+            configMapKeyRef:
+              name: linkerd-cni-config
+              key: cni_network_config
         volumeMounts:
         {{- if ne .Values.destCNIBinDir .Values.destCNINetDir }}
         - mountPath: /host{{.Values.destCNIBinDir}}

--- a/helm/linkerd2-cni/templates/cni-plugin.yaml
+++ b/helm/linkerd2-cni/templates/cni-plugin.yaml
@@ -278,6 +278,7 @@ spec:
         {{- if .Values.resources }}
         {{- include "partials.resources" .Values.resources | nindent 8 }}
         {{- end }}
+      {{- if .Values.nodeTaint.enabled }}
       - name: node-taint
         image: "{{ .Values.image.registry }}/giantswarm/docker-kubectl:1.24.2"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -331,6 +332,7 @@ spec:
         {{- if .Values.resources }}
         {{- include "partials.resources" .Values.resources | nindent 8 }}
         {{- end }}
+      {{- end }}
       volumes:
       {{- if ne .Values.destCNIBinDir .Values.destCNINetDir }}
       - name: cni-bin-dir

--- a/helm/linkerd2-cni/templates/cni-plugin.yaml
+++ b/helm/linkerd2-cni/templates/cni-plugin.yaml
@@ -112,9 +112,11 @@ rules:
 - apiGroups: [""]
   resources: ["pods", "nodes", "namespaces", "services"]
   verbs: ["list", "get", "watch"]
+{{- if .Values.nodeTaint.enabled }}
 - apiGroups: [""]
   resources: ["nodes"]
   verbs: ["patch"]
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/helm/linkerd2-cni/values.yaml
+++ b/helm/linkerd2-cni/values.yaml
@@ -78,6 +78,10 @@ image:
 # which will further orchestrate the deployments.
 imagePullSecrets: []
 
+
+nodeTaint:
+  enabled: false
+
 # -- Add additional initContainers to the daemonset
 extraInitContainers: []
 # - name: wait-for-other-cni

--- a/helm/linkerd2-cni/values.yaml
+++ b/helm/linkerd2-cni/values.yaml
@@ -52,6 +52,9 @@ tolerations:
     operator: Exists
   - key: node-role.kubernetes.io/master
     operator: Exists
+  - key: node-role.kubernetes.io/control-plane
+    operator: Exists
+
 
 # -|- NodeAffinity section, See the
 # [K8S documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity)

--- a/helm/linkerd2-cni/values.yaml
+++ b/helm/linkerd2-cni/values.yaml
@@ -48,7 +48,10 @@ privileged: false
 # for more information
 tolerations:
   # -- toleration properties
-  - operator: Exists
+  - key: node.giantswarm.io/mesh-not-ready
+    operator: Exists
+  - key: node-role.kubernetes.io/master
+    operator: Exists
 
 # -|- NodeAffinity section, See the
 # [K8S documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity)
@@ -77,7 +80,6 @@ image:
 # The pull secrets are applied to the respective service accounts
 # which will further orchestrate the deployments.
 imagePullSecrets: []
-
 
 nodeTaint:
   enabled: false


### PR DESCRIPTION
This PR adds a container that removes a taint from the node in which the pod is running.

Towards https://github.com/giantswarm/giantswarm/issues/27073

A few things are happening here:

1. add a new container, which checks if the Linkerd CNI was installed successfully and then remove the taint of node in which the pod is running. If the taint is not there, it doesn't do anything.
2. The pod now needs patch on the node.
3. Removed the overly permissive tolerations to avoid scheduling the CNI on nodes where Cilium is not yet installed. 

## Checklist

- [x] Automated test are working (for chart changes)
- [x] I am confident my changes don't break existing installations (for chart changes)
- [x] Changelog entry has been added
